### PR TITLE
Fix for dimensions being ticked w/ the same clock

### DIFF
--- a/morph/common/core/TickHandlerServer.java
+++ b/morph/common/core/TickHandlerServer.java
@@ -78,13 +78,25 @@ implements ITickHandler
 	public void preWorldTick(WorldServer world)
 	{
 	}
+	
+	private HashMap<Integer, Long> clocks = new HashMap<Integer, Long>();
+	private long getLastClock(WorldServer world)
+	{
+		if (clocks.containsKey(world.provider.dimensionId)) return clocks.get(world.provider.dimensionId);
+		return -1;
+	}
+	
+	private long updateLastClock(WorldServer world)
+	{
+		long clock = world.getTotalWorldTime();
+		clocks.put(world.provider.dimensionId, clock);
+		return clock;
+	}
 
 	public void worldTick(WorldServer world)
 	{
-		if(clock != world.getWorldTime() || !world.getGameRules().getGameRuleBooleanValue("doDaylightCycle"))
+		if(getLastClock(world) != updateLastClock(world))
 		{
-			clock = world.getWorldTime();
-
 //						for(int i = 0 ; i < world.loadedEntityList.size(); i++)
 //						{
 //							if(world.loadedEntityList.get(i) instanceof EntityCow)

--- a/morph/common/morph/MorphState.java
+++ b/morph/common/morph/MorphState.java
@@ -43,6 +43,7 @@ public class MorphState
 		{
 			NBTTagCompound fakeTag = new NBTTagCompound();
 			entInstance.writeEntityToNBT(fakeTag);
+			fakeTag.removeTag("bukkit");
 			writeFakeTags(entInstance, fakeTag);
 			identifier = entInstance.getClass().toString() + entInstance.getEntityName() + fakeTag.toString();
 		}


### PR DESCRIPTION
This should fix the issues that manifested themselves w/ MCPC+

1) In TickHandlerServer, the code block that was progressing a morph only happens when it is dimension 0 (https://github.com/OniBait/Morph/blob/2a3418441f772c741254b0bbd54df9d398ddabac/morph/common/core/TickHandlerServer.java#L243) but that block is inside the check against whether the clock has changed since the last world tick. Since MCPC+ loads Dimension -1 and Dimension 0 at startup, they share the same clock as well as the chance that Dimension -1 will get ticked first, so the inner block was never getting called.

Note: This has the potential to happen in Vanilla Forge if any dimensions < 0 get loaded at startup (ex: DimensionalDoors or Galacticraft) which is why I'm submitting the fix to you vs. putting a hack into MCPC+ to always tick dim 0 first.

I added some (admittedly ugly) code that should keep track of the clock per dimension (which I believe is the intended behavior anyway).

2) The NBT for EntityPlayerMP contains some custom data in a tag named "bukkit" which happens to include "LastPlayedTime", which when writing the NBT is always set to the current time. The problem here is that when the player first connects, morph is sending the player's NBT down to the client and then using the player's NBT later on when it saves the morphs. This causes the player's key to be out of sync with the server (only happens the first time I think, but w/e) -- the fix is to remove any NBT tags named "bukkit" when setting up the MorphState.identifier

Have tested this with both MCPC+ and Vanilla Forge and it all works as expected.
