### PR TITLE
Update ModMobSupport.json

### DIFF
--- a/assets/morph/mod/ModMobSupport.json
+++ b/assets/morph/mod/ModMobSupport.json
@@ -44,7 +44,7 @@
     ],
     "am2.entities.EntityHecate": [
       "sunburn",
-      "fly|false",
+      "fly|true",
       "hostile"
     ],
     "am2.entities.EntityHellCow": [


### PR DESCRIPTION
Hecates are listed in their respective mod as a flying creature. Why not have that the case in morph?
