### PR TITLE
Update ModMobSupport.json

### DIFF
--- a/assets/morph/mod/ModMobSupport.json
+++ b/assets/morph/mod/ModMobSupport.json
@@ -681,6 +681,7 @@
     ],
     "thaumcraft.common.entities.monster.EntityFireBat": [
       "fireImmunity",
+      "waterAllergy",
       "fly|true",
       "hostile"
     ],


### PR DESCRIPTION
Added waterallergy for Thaumcraft firebat since they spawn only in the Nether, correct me if I'm wrong but creatures that spawn in the Nether don't like water... (a flying creature that can go in the lava and in the water was a little bit OP for my taste too)
