### PR TITLE
Update es_ES.lang

### DIFF
--- a/assets/morph/lang/es_ES.lang
+++ b/assets/morph/lang/es_ES.lang
@@ -12,5 +12,5 @@ morph.gui.keybinds.left=Izquierda
 morph.gui.keybinds.right=Derecha
 morph.gui.keybinds.choose=Escoger
 morph.gui.keybinds.cancel=Cancelar
-morph.gui.keybinds.remove=Remover
+morph.gui.keybinds.remove=Eliminar
 morph.gui.keybinds.favorite=Favorito


### PR DESCRIPTION
Fixes 'remove' translation, uses 'eliminar' instead of 'remover' (a false friend which means to stir or to move).
