### PR TITLE
Fixes for large Servers

### DIFF
--- a/src/main/java/morph/common/core/EventHandler.java
+++ b/src/main/java/morph/common/core/EventHandler.java
@@ -1678,6 +1678,8 @@ public class EventHandler
                 Morph.proxy.tickHandlerServer.getMorphDataFromPlayer(event.player).setTag("morphState" + i, states.get(i).getTag());
             }
         }
+        Morph.proxy.tickHandlerServer.playerMorphs.remove(event.player.getCommandSenderName())
+        Morph.proxy.tickHandlerServer.playerMorphInfo.remove(event.player.getCommandSenderName());
     }
 
     @SubscribeEvent


### PR DESCRIPTION
One thing that is a constant problem is on multiplayer servers morphs is preventing them to startup after a while. As we know very well that NBT data files can be huge without problems, it can only mean one thing, the HashMap. It can be efficient to store all data in single player servers on a hash map until the server is restarted as you only have 1 - 5 players on. But this becomes problematic on large servers that have thousands of players. If all players joined throughout a day are kept loaded in the map even if they are not on, would result in a large amount of lag due to space required to hold everything in a map. A solution is to remove the player from the map on logout, as this prevents server owners from having to do constant restarts.
