### PR TITLE
Allow the Wither To fly

### DIFF
--- a/src/main/resources/assets/morph/mod/AbilitySupport.json
+++ b/src/main/resources/assets/morph/mod/AbilitySupport.json
@@ -2174,7 +2174,7 @@
     "swim|false,1.2F,0.4F,true"
   ],
   "net.minecraft.entity.boss.EntityWither": [
-    "fly|false",
+    "fly|true",
     "fireImmunity",
     "hostile",
     "witherResistance"


### PR DESCRIPTION
For some reason, this says that the wither should NOT be able to fly, although clearly it can fly in the game.