### PR TITLE
Update nbt_modifiers with FoolCraft3 / Waffleton creature mods

### DIFF
--- a/src/main/resources/assets/morph/mod/nbt_modifiers.json
+++ b/src/main/resources/assets/morph/mod/nbt_modifiers.json
@@ -56,18 +56,25 @@
     "ForgeData_BeeBarker3": "ForgeData:BeeBarker_beeCharge;null",
     "hitByDarkSteelSword": "null",
     "ForgeData_ezModsApp": "ForgeData:exModsApp;null",
-    "EggLayTime": "null",
+    "ForgeData_cnpcmarks": "ForgeData:cnpcmarkdata:marks;null",
+    "ForgeData_spawnedByPoweredSpawner": "ForgeData:spawnedByPoweredSpawner;null",
+    "ForgeData_CursedEarth": "ForgeData:CursedEarth;null"
+  },
+  "nex.entity.monster.EntitySpinout": {
     "Spinning": "null",
     "SpinCounter": "null",
-    "SpinCooldown": "null",
-    "ForgeData_cnpcmarks": "ForgeData:cnpcmarkdata:marks;null",
-    "Counter": "null",
+    "SpinCooldown": "null"
+  },
+  "nex.entity.monster.EntitySpore": {
+    "Counter": "null"
+  },
+  "com.setycz.chickens.entity.EntityChickensChicken": {
     "Analyzed": "null",
     "Gain": "null",
     "Growth": "null",
     "Strength": "null",
-    "ForgeData_spawnedByPoweredSpawner": "ForgeData:spawnedByPoweredSpawner;null",
-    "ForgeData_CursedEarth": "ForgeData:CursedEarth;null"
+    "EggLayTime": "null",
+    "Type": "null"
   },
   "net.minecraft.entity.boss.EntityWither": {
     "Invul": "null"

--- a/src/main/resources/assets/morph/mod/nbt_modifiers.json
+++ b/src/main/resources/assets/morph/mod/nbt_modifiers.json
@@ -53,7 +53,21 @@
     "ForgeData_Hats": "ForgeData:Hats_hatInfo;null",
     "ForgeData_BeeBarker1": "ForgeData:BeeBarker_barkable;null",
     "ForgeData_BeeBarker2": "ForgeData:BeeBarker_beeHighestCharge;null",
-    "ForgeData_BeeBarker3": "ForgeData:BeeBarker_beeCharge;null"
+    "ForgeData_BeeBarker3": "ForgeData:BeeBarker_beeCharge;null",
+    "hitByDarkSteelSword": "null",
+    "ForgeData_ezModsApp": "ForgeData:exModsApp;null",
+    "EggLayTime": "null",
+    "Spinning": "null",
+    "SpinCounter": "null",
+    "SpinCooldown": "null",
+    "ForgeData_cnpcmarks": "ForgeData:cnpcmarkdata:marks;null",
+    "Counter": "null",
+    "Analyzed": "null",
+    "Gain": "null",
+    "Growth": "null",
+    "Strength": "null",
+    "ForgeData_spawnedByPoweredSpawner": "ForgeData:spawnedByPoweredSpawner;null",
+    "ForgeData_CursedEarth": "ForgeData:CursedEarth;null"
   },
   "net.minecraft.entity.boss.EntityWither": {
     "Invul": "null"

--- a/src/main/resources/assets/morph/mod/nbt_modifiers.json
+++ b/src/main/resources/assets/morph/mod/nbt_modifiers.json
@@ -19,11 +19,25 @@
     "additionalNote2": "Please keep this list alphabetically sorted when you add your own mobs. Keep Minecraft classes as the bottom. Keep the examples at the top.",
     "additionalNote3": "You can also add compatibility for your own mod via the IMC system. Look in the Morph main class for documentation."
   },
-
+  "com.setycz.chickens.entity.EntityChickensChicken": {
+    "Analyzed": "null",
+    "Gain": "null",
+    "Growth": "null",
+    "Strength": "null",
+    "EggLayTime": "null",
+    "Type": "null"
+  },
   "crazypants.enderzoo.entity.EntityOwl": {
     "EggLayTime": "null"
   },
-
+  "nex.entity.monster.EntitySpinout": {
+    "Spinning": "null",
+    "SpinCounter": "null",
+    "SpinCooldown": "null"
+  },
+  "nex.entity.monster.EntitySpore": {
+    "Counter": "null"
+  },
   "net.minecraft.entity.EntityLivingBase": {
     "Fire": "null",
     "Riding": "null",
@@ -59,22 +73,6 @@
     "ForgeData_cnpcmarks": "ForgeData:cnpcmarkdata:marks;null",
     "ForgeData_spawnedByPoweredSpawner": "ForgeData:spawnedByPoweredSpawner;null",
     "ForgeData_CursedEarth": "ForgeData:CursedEarth;null"
-  },
-  "nex.entity.monster.EntitySpinout": {
-    "Spinning": "null",
-    "SpinCounter": "null",
-    "SpinCooldown": "null"
-  },
-  "nex.entity.monster.EntitySpore": {
-    "Counter": "null"
-  },
-  "com.setycz.chickens.entity.EntityChickensChicken": {
-    "Analyzed": "null",
-    "Gain": "null",
-    "Growth": "null",
-    "Strength": "null",
-    "EggLayTime": "null",
-    "Type": "null"
   },
   "net.minecraft.entity.boss.EntityWither": {
     "Invul": "null"


### PR DESCRIPTION
minecraft:creeper (and others) : hitByDarkSteelSword and ForgeData/ezModsApp, ForgeData/cnpcmarks/marks (I hope I represented that right)
exoticbirds:pigeon (and same mod) : EggLayTime  (sorry I can't figure out the class as it only records entID)
nex:monster_spinout : Spinning, SpinCounter, SpinCooldown (this comes from NetherEx mod - sorry no idea the class name again)
nax:monster_spore: Counter
CustomNpcs:  ... there is tonnes of stuff... is there a way to just block this mod of all tags?
morechickens:[copperchicken]: Analyzed, Gain, Grown, Strength (creates 100s of entities in the nbt - sorry again no idea how to derive the class name)
Misc witherskelly: spawnedByPoweredSpawner
Misc Blaze: CursedEarth


Thank you very much for your consideration - if you can let me know how to retrieve the classnames, I can split the relevant lines out to not affect all creatures.