### PR TITLE
Make EventServerHandler thread safe

### DIFF
--- a/src/main/java/me/ichun/mods/morph/common/core/EventHandlerServer.java
+++ b/src/main/java/me/ichun/mods/morph/common/core/EventHandlerServer.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class EventHandlerServer
 {
@@ -226,6 +227,6 @@ public class EventHandlerServer
         return morphs;
     }
 
-    public HashMap<String, MorphInfo> morphsActive = new HashMap<>(); //These are the active morphs. Entity instance are retreived from here
-    public HashMap<String, ArrayList<MorphVariant>> playerMorphs = new HashMap<>();//These are the available morphs for each player. No entity instance is required or created here.
+    public Map<String, MorphInfo> morphsActive = new ConcurrentHashMap<>(); //These are the active morphs. Entity instance are retreived from here
+    public Map<String, ArrayList<MorphVariant>> playerMorphs = new ConcurrentHashMap<>();//These are the available morphs for each player. No entity instance is required or created here.
 }


### PR DESCRIPTION
To prevent this:
```
// My bad.

Time: 1/12/19 2:45 AM
Description: Exception in server tick loop

java.util.ConcurrentModificationException
	at java.util.HashMap$HashIterator.nextNode(HashMap.java:1442)
	at java.util.HashMap$KeyIterator.next(HashMap.java:1466)
	at me.ichun.mods.mmec.common.core.EventHandlerServer.onServerTick(EventHandlerServer.java:88)
	at net.minecraftforge.fml.common.eventhandler.ASMEventHandler_1165_EventHandlerServer_onServerTick_ServerTickEvent.invoke(.dynamic)
	at net.minecraftforge.fml.common.eventhandler.ASMEventHandler.invoke(ASMEventHandler.java:90)
	at net.minecraftforge.fml.common.eventhandler.EventBus.post(EventBus.java:687)
	at net.minecraftforge.fml.common.eventhandler.EventBus.post(EventBus.java:641)
	at net.minecraftforge.fml.common.FMLCommonHandler.onPostServerTick(FMLCommonHandler.java:266)
	at net.minecraft.server.MinecraftServer.func_71217_p(MinecraftServer.java:712)
	at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:526)
	at java.lang.Thread.run(Thread.java:748)


A detailed walkthrough of the error, its code path and all known details is as follows:
---------------------------------------------------------------------------------------

-- Head --
Thread: Server thread
Stacktrace:
	at java.util.HashMap$HashIterator.nextNode(HashMap.java:1442)
	at java.util.HashMap$KeyIterator.next(HashMap.java:1466)
	at me.ichun.mods.mmec.common.core.EventHandlerServer.onServerTick(EventHandlerServer.java:88)
	at net.minecraftforge.fml.common.eventhandler.ASMEventHandler_1165_EventHandlerServer_onServerTick_ServerTickEvent.invoke(.dynamic)
	at net.minecraftforge.fml.common.eventhandler.ASMEventHandler.invoke(ASMEventHandler.java:90)
	at net.minecraftforge.fml.common.eventhandler.EventBus.post(EventBus.java:687)

-- Sponge PhaseTracker --
Details:
	Phase Stack: [Empty stack]
Stacktrace:
	at net.minecraft.server.MinecraftServer.handler$onCrashReport$zjl000(MinecraftServer.java:3980)
	at net.minecraft.server.MinecraftServer.func_71230_b(MinecraftServer.java:889)
	at net.minecraft.server.dedicated.DedicatedServer.func_71230_b(DedicatedServer.java:371)
	at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:558)
at java.lang.Thread.run(Thread.java:748)
```